### PR TITLE
Let lang-docs manage the Cookbook

### DIFF
--- a/people/AndyGauge.toml
+++ b/people/AndyGauge.toml
@@ -1,0 +1,5 @@
+name = "Andrew Gauger"
+github = "AndyGauge"
+github-id = 6525150
+zulip-id = 257582
+email = "andygauge@gmail.com"

--- a/repos/rust-lang-nursery/rust-cookbook.toml
+++ b/repos/rust-lang-nursery/rust-cookbook.toml
@@ -1,0 +1,7 @@
+org = "rust-lang-nursery"
+name = "rust-cookbook"
+description = "https://rust-lang-nursery.github.io/rust-cookbook"
+bots = []
+
+[access.teams]
+cookbook = "write"

--- a/repos/rust-lang-nursery/rust-cookbook.toml
+++ b/repos/rust-lang-nursery/rust-cookbook.toml
@@ -5,3 +5,4 @@ bots = []
 
 [access.teams]
 cookbook = "write"
+lang-docs = "write"

--- a/teams/cookbook.toml
+++ b/teams/cookbook.toml
@@ -1,0 +1,15 @@
+name = "cookbook"
+subteam-of = "lang-docs"
+
+[people]
+leads = ["AndyGauge"]
+members = ["AndyGauge"]
+alumni = []
+
+[[github]]
+orgs = ["rust-lang-nursery"]
+
+[website]
+name = "Cookbook team"
+description = "Maintains the Rust Cookbook"
+repo = "https://github.com/rust-lang-nursery/rust-cookbook/"

--- a/teams/lang-docs.toml
+++ b/teams/lang-docs.toml
@@ -16,7 +16,7 @@ alumni = [
 ]
 
 [[github]]
-orgs = ["rust-lang"]
+orgs = ["rust-lang", "rust-lang-nursery"]
 
 [website]
 name = "lang-docs team"


### PR DESCRIPTION
On lang-docs, we should probably be able to manage the Cookbook repo, so let's add what's needed for that.

See:

- https://github.com/rust-lang/team/pull/1800